### PR TITLE
Inkluderer flyreiser i teksten for bonusprogram

### DIFF
--- a/src/pages/processes.md
+++ b/src/pages/processes.md
@@ -124,7 +124,7 @@ eposten som lister ut deltagere.
 
 ### Bonuspoeng og rabatt
 
-I Variant sier vi at vi ikke skal bruke kredittkort eller fordelsprogram med reiser med bonusprogram når du betaler/dekker utgifter for selskapet. Jf. lovendringer fra 01.0.1.2019 er all bonuspoeng skattbart og selskap har ansvar for å holde orden på det. Dette er i praksis umulig og det er enklest å si at vi unngår det helt.
+I Variant sier vi at vi ikke skal bruke fordelsprogram som gir bonus når du betaler eller dekker utgifter for selskapet. Jf. lovendringer fra 01.0.1.2019 er opptjening av bonuspoeng med arbeidsgivers midler skattbart og selskap har ansvar for å holde orden på det. Dette er i praksis umulig og det er enklest å si at vi unngår det helt. Dette gjelder f.eks bonusreiser på fly og kredittkort med bonusprogram. 
 
 ## Timeføring
 

--- a/src/pages/processes.md
+++ b/src/pages/processes.md
@@ -124,7 +124,7 @@ eposten som lister ut deltagere.
 
 ### Bonuspoeng og rabatt
 
-I Variant sier vi at vi ikke skal bruke kredittkort med bonusprogram når du betaler/dekker utgifter for selskapet. Jf. lovendringer fra 01.0.1.2019 er all bonuspoeng via kredittkort skattbart og hvor Variant har ansvar for å holde orden på det. Dette er i praksis umulig og det er enklest å si at vi unngår det helt.
+I Variant sier vi at vi ikke skal bruke kredittkort eller fordelsprogram med reiser med bonusprogram når du betaler/dekker utgifter for selskapet. Jf. lovendringer fra 01.0.1.2019 er all bonuspoeng skattbart og selskap har ansvar for å holde orden på det. Dette er i praksis umulig og det er enklest å si at vi unngår det helt.
 
 ## Timeføring
 


### PR DESCRIPTION
Langvarig endring i #9. Ble litt for snever da den ikke inkluderte fordelsprogram for flyreiser utenom kredittkort (f.eks eurobonus fra SAS). Prøver meg på en endring i teksten for å være mer generell.