### PR TITLE
Fikser visning av mobilmeny etter flere menyer ble introdusert

### DIFF
--- a/src/layout.html
+++ b/src/layout.html
@@ -46,10 +46,12 @@
         <button type="button" aria-haspopup="true" aria-expanded="false" aria-controls="menu" aria-label="Navigation"
           class="toggleMenu" title="Toggle menu">☰</button>
 
-        {{NAV}}
+        <div class="menuContainer">
+          {{NAV}}
 
-        <h3>Innhold</h3>
-        {{TOC}}
+          <h3>Innhold</h3>
+          {{TOC}}
+        </div>
 
         <div class="toc__suffix">
           <div class="toc_question">

--- a/src/static/main.js
+++ b/src/static/main.js
@@ -38,7 +38,7 @@
   const tocTop = document.querySelector(".toc");
   tocTop.classList.add("jsActive");
 
-  const toc = document.querySelector(".markdownIt-TOC");
+  const toc = document.querySelector(".menuContainer");
   toc.setAttribute("role", "navigation");
   toc.setAttribute("id", "menu");
   toc.classList.add("jsActive");
@@ -47,10 +47,10 @@
   button.classList.add("jsActive");
 
   button.addEventListener("click", function() {
-    toc.classList.toggle("markdownIt-TOC--visible");
+    toc.classList.toggle("menuContainer--visible");
   });
   toc.addEventListener("click", function() {
-    toc.classList.toggle("markdownIt-TOC--visible");
+    toc.classList.toggle("menuContainer--visible");
   });
 
   // Add service worker if supported

--- a/src/static/styles/style.css
+++ b/src/static/styles/style.css
@@ -174,7 +174,7 @@ code {
 
 .markdownIt-TOC {
   list-style-type: lower-roman;
-  padding-left: inherit;
+  padding-left: 2rem;
 }
 .toc ul li {
   color: var(--lightPink);
@@ -412,7 +412,7 @@ p {
     display: none;
   }
 
-  .markdownIt-TOC {
+  .menuContainer {
     background: var(--white);
     padding: var(--defaultMargin);
     padding-left: calc(var(--defaultMargin) * 1.5);
@@ -426,14 +426,14 @@ p {
     max-height: calc(100vh - 4rem);
     overflow: auto;
   }
-  .markdownIt-TOC.jsActive {
+  .menuContainer.jsActive {
     position: absolute;
     width: 100%;
     top: 100%;
     transform: translateY(calc(-100% - var(--defaultMargin) * 3));
     margin: 0;
   }
-  .markdownIt-TOC--visible.jsActive {
+  .menuContainer--visible.jsActive {
     transform: translateY(0);
   }
 


### PR DESCRIPTION
Innførte en bug i #20 ettersom vis/skjul meny baserte seg på UL. Når det var flere menyer med samme klasse/på samme nivå ble det krøll. Denne PR-en løser det med å introdusere en container som wrapper begge menyene.