### PR TITLE
Spellcheck handbook

### DIFF
--- a/src/pages/handbook.md
+++ b/src/pages/handbook.md
@@ -206,8 +206,8 @@ ingen rolle.
 
 Kjernevirksomheten til Variant er i utgangspunktet utelukkende å selge
 kompetanse. Men vi er eksperimentelle og tilpasningsdyktige. Det kan komme en
-tid der vi ser på muligheten for å samarbeide tett med start-ups eller skape
-egne start-ups. I Norge er det helt vanlig at arbeidsplassen innehar rettigheter
+tid der vi ser på muligheten for å samarbeide tett med startups eller skape
+egne startups. I Norge er det helt vanlig at arbeidsplassen innehar rettigheter
 til det ansatte måtte lage eller komme på. Det kan være vanskelig å komme seg
 rundt dersom Variant har brukt mye penger på å hjelpe ansatte å utvikle noe.
 
@@ -308,7 +308,7 @@ har gode forutsetninger for å levere godt resultat for våre kunder over lang
 tid. Godt med lys, luft og riktige møbler er avgjørende i så måte.
 
 Variant har igjennom året flere aktiviteter hvor våre ansatte har mulighet til
-fysisk aktivitet. Dette er kan være fjellturer, bedriftsidrett, fiske etc. I
+fysisk aktivitet. Dette er kan være fjellturer, bedriftsidrett, fiske osv. I
 tillegg dekker Variant 3T-medlemskapet for de av våre ansatte som synes et
 treningssenter er et hyggelig sted å være.
 
@@ -416,7 +416,7 @@ begge parter ønsker seg i samme retning.
 
 En av tankene bak å etablere Variant var at selskapet skulle styres og eies med
 lokal forankring. Vi finnes i Trondheim, og skal i hovedsak betjene kunder i
-midtnorge. Da mener vi at selskapet skal styres med folk som kjenner midtnorge
+Midt-Norge. Da mener vi at selskapet skal styres med folk som kjenner Midt-Norge
 og markedet her.
 
 I 2018 etablerte 6 personer Variant, alle med base i Trondheim. I dag er
@@ -446,7 +446,7 @@ Se også vår oversikt over [interne prosedyrer](./information.html).
 
 Ofte kjedelig, men like fullt nødvendig. Det er tross alt timer vi lever av å
 selge. Derfor forsøker vi å gjøre det så lett som mulig å levere inn
-timerapporten hver uke. Jeps, hver uke. Fristen er mandag morgen kl 9.00 den
+timerapporten hver uke. Jeps, hver uke. Fristen er mandag morgen kl. 9.00 den
 påfølgende uken. Timene føres i [Harvest](https://variantas.harvestapp.com/).
 Herfra kan man også laste ned Apps for både Mac, Windows og telefoner.
 
@@ -455,7 +455,7 @@ Se mer detaljer om hvordan
 
 ### Hovedkvarteret
 
-Vi har våre kontorer på arbeidsfellesskapet Digs i Olav Tryggvassonsgate. Her
+Vi har våre kontorer på arbeidsfellesskapet Digs i Olav Tryggvasonsgate. Her
 har vi et eget kontor med 3-4 plasser. Her har vi tilgang til gode møterom og
 kontorutstyr. Det er også her vi kjører våre variantdager. På Digs jobber vi
 sammen med en rekke startups og andre spennende selskaper. Her har vi mulighet

--- a/src/pages/handbook.md
+++ b/src/pages/handbook.md
@@ -455,7 +455,7 @@ Se mer detaljer om hvordan
 
 ### Hovedkvarteret
 
-Vi har våre kontorer på arbeidsfellesskapet Digs i Olav Tryggvasonsgate. Her
+Vi har våre kontorer på arbeidsfellesskapet Digs i Olav Tryggvasons gate. Her
 har vi et eget kontor med 3-4 plasser. Her har vi tilgang til gode møterom og
 kontorutstyr. Det er også her vi kjører våre variantdager. På Digs jobber vi
 sammen med en rekke startups og andre spennende selskaper. Her har vi mulighet

--- a/src/pages/information.md
+++ b/src/pages/information.md
@@ -12,20 +12,20 @@ og hvilke regler som gjelder.
 
 Her er noen snarveier:
 
-- [How toguides](https://digs.officernd.com/links?office=565748274a955c790d808c77)
+- [How to-guides](https://digs.officernd.com/links?office=565748274a955c790d808c77)
   Blant annet hvordan printer og kaffemaskina fungerer.
 - [Møteromsbooking](https://digs.officernd.com/calendar?type=meeting_room&office=565748274a955c790d808c77)
-  Vi kan desverre ikke gjøre dette direkte fra Outlook.
+  Vi kan dessverre ikke gjøre dette direkte fra Outlook.
 - [Terms & Good-To-Know](https://digs.officernd.com/terms-good-to-know?office=565748274a955c790d808c77)
   Noen husregler
 
 ### WiFi
 
 Hvis du jobber på kontoret benytter du det trådløse nettet med SSID **DIGS**.
-Ved oppstart har du fått en epost med emne: "Account Confirmation" **NB!** Denne
+Ved oppstart har du fått en e-post med emne: "Account Confirmation" **NB!** Denne
 kan ha havnet i spam-folderen. Følg linken i denne eposten for å sette passord.
 
-Hvis du har glemt passordet til det trådløsenettet kan du
+Hvis du har glemt passordet til det trådløse nettet kan du
 [endre det her](http://intranett.digs.no/user/forgot).
 
 ## Lønning
@@ -63,13 +63,13 @@ ekstra info.
 ## Utgiftsrapportering
 
 Utgiftsrapporter føres teknisk på samme måte som fakturaer, ved at en sender en
-mail til faktura@variant.no, men legg inn "UTGIFTSRAPPORT" i subjectfeltet. Ta
+mail til faktura@variant.no, men legg inn "UTGIFTSRAPPORT" i emnefeltet. Ta
 bilde av kvitteringer og skriv inn samlet beløp i mailen.
 
-### Resturantbesøk
+### Restaurantbesøk
 
 Av bokføringsgrunner trenger vi å vite hvem som var med når noen har lagt ut for
-et resurantbesøk. Dette gjelder både eksterne og interne. Lag en enkel liste i
+et restaurantbesøk. Dette gjelder både eksterne og interne. Lag en enkel liste i
 eposten som lister ut deltagere.
 
 ### Reiser
@@ -97,18 +97,18 @@ Folk har lurt "Dette gadget-budsjettet deres, hva kan det brukes til?" og svaret
 er at bare
 [Skatteetatens definisjon](https://www.skatteetaten.no/rettskilder/type/handboker/skatte-abc/2018/naturalytelser-i-arbeidsforhold/N-1.017/N-1.034/#4-14-2-arbeidsgivers-utplassering-av-datautst)
 setter grenser. Kort oppsummert: Mobiltelefon, programvare og datautstyr som
-f.eks hodetelefoner og tastur. Se gjerne
+f.eks hodetelefoner og tastatur. Se gjerne
 [gadgetoversikten](https://gadget.variant.no) hva andre varianter har kjøpt.
 Kjøp av gadgets er skattefritt og utgiftsføres med en vanlig utgiftsrapport.
 Hvis du er i tvil så spør du i #regnskap på Slack.
 
-Pro tip: Tenk på att summen av kjøpet ditt regnes eksklusive mva., da rekker
+Pro tip: Tenk på at summen av kjøpet ditt regnes eksklusive mva., da rekker
 budsjettet ditt lenger!
 
 ## Fordelsprogram og rabatt
 
 Skattemydighetene krever at fordeler du oppnår gjennom ulike fordelsprogam man
-får på grunn av at du er ansatt hos oss skal rapporeres inn slik at det blir med
+får på grunn av at du er ansatt hos oss skal rapporteres inn slik at det blir med
 på skatteberegningen. Dette gjelder blant annet:
 
 - Kredittkort med bonuspoeng
@@ -138,7 +138,7 @@ Du må også dokumentere estimert verdi. Dette gjøres typisk ved å ta skjermbi
 av tilsvarende kjøp eller reiser hvor prisene er oppgitt.
 
 - Dokumentasjonen lastes opp på [docs](https://fordelsdokumentasjon.variant.no).
-- Rapprtering gjøres ved å fylle ut
+- Rapportering gjøres ved å fylle ut
   [dette skjemaet](https://fordelsrapport.variant.no).
 
 ## Timeføring
@@ -169,7 +169,7 @@ Av annen tid vi sporer har disse aktivitetene:
 For alle disse kan man føre inntil 7,5 timer pr dag. Bortsett fra Variantdag kan
 summen av fakturerbar tid og den av disse ikke overstige 7,5 timer pr dag.
 
-Er du på kurs, konferanse, meetup eller annen kompetansaktivitet fører du ikke
+Er du på kurs, konferanse, meetup eller annen kompetanseaktivitet fører du ikke
 dette. Tilsvarende om du jobber med salg, rekruttering eller lignende interne
 aktiviteter.
 
@@ -233,7 +233,7 @@ ikke rett på sykepenger fra NAV før du har blitt frisk og jobbet sammenhengend
 i4 uker. _Dette siste avsnittet er spesielt relevant for nyutdannede som kommer
 rett fra skolen._
 
-## Portere telefonabonement
+## Portere mobilabonnement
 
 For at Variant skal betale for mobilbruk må abonnementet overføres til Variant
 AS. Framgangsmåten for å overføre abonnementet til Variant er avheng av hvem som
@@ -251,7 +251,7 @@ Eller hvis noen andre, typisk tidligere arbeidsgiver, eier abonnementet:
 1. Last ned det delvis utfylte
    [eierskifteskjemaet](https://varianttrh.sharepoint.com/:b:/g/EfSJeOxZz3REsF46oO0ZOiMBG0MMQETWLOom-yxMXrqYnA?e=ijXDmg)
 1. Fyll ut resten, og få dagens eier til å signere.
-1. Send skjemaet på epost til skjema-eierskifte@telia.no
+1. Send skjemaet på e-post til skjema-eierskifte@telia.no
 1. Gi beskjed på [#helpdesk](slack://channel?id=CBFA8V536&team=T7FAZ8XT2) om at
    skjema er sendt inn og at portering kan iverksettes.
 
@@ -273,8 +273,8 @@ Eller hvis noen andre, typisk tidligere arbeidsgiver, eier abonnementet:
 ## Nyttige lenker
 
 - [Gadgetoversikt](https://gadget.variant.no) Oversikt over hva som er kjøpt på
-  gadsjett, og hvor mye man har brukt.
+  gadget, og hvor mye man har brukt.
 - [Fordelsrapport](https://fordelsrapport.variant.no) Her rapporteres det inn
   bruk av bonuspoenge eller andre fordelsprogam.
 - [Fordelsdokumentasjonen](https://fordelsdokumentasjon.variant.no) Hit laster
-  du opp dokumentasjon på overnevnt bruk.
+  du opp dokumentasjon på ovennevnt bruk.

--- a/src/pages/quality_manual.md
+++ b/src/pages/quality_manual.md
@@ -25,7 +25,7 @@ vinner nok salg. Variants tilbud skal alltid levere over kundens forventninger.
 ### Salgsprosess
 
 For å håndtere salgsprosessen benytter vi en enkel
-[trello-tavle](https://trello.com/b/kO5kbMNf/salg) som verktøy. En salgsmulighet
+[Trello-tavle](https://trello.com/b/kO5kbMNf/salg) som verktøy. En salgsmulighet
 representeres med et kort i Trello, og tavlen representerer en salgstrakt hvor
 muligheter trekkes gjennom ulike salgsfaser til muligheten har blitt konkludert
 med.
@@ -154,7 +154,7 @@ Verneombud fra 2019 er Ellen Wagnild-Antonsen.
 
 ### Fysiske lokaler
 
-Variant er et konsulentselskap, der hvor mange ansattae tilbringer store deler
+Variant er et konsulentselskap, der hvor mange ansatte tilbringer store deler
 av arbeidstiden ute i kundenes lokaler. HMS-håndboka dekker proaktivt arbeid med
 lokaler, men vi avgrenser dette til vårt kontor på DIGS.
 
@@ -195,12 +195,12 @@ at de oppstår på nytt.
 Meld fra om feil og mangler til daglig leder. Feil og mangler skal rettes opp
 der problemet oppstår.
 
-Eventuelle tiltak for å rette opp i disse feil eller mangeler skal registerets i
+Eventuelle tiltak for å rette opp i disse feil eller mangler skal registerets i
 handlingsplanen.
 
 ### [Handlingsplan](https://trello.com/b/DQX0sirR/operativt)
 
-Selve handlingsplanen er implementert som en egen liste i trelloboardet
+Selve handlingsplanen er implementert som en egen liste i Trello-tavlen
 operativt. Ledergruppen har ansvaret for at handlingsplanen blir fulgt og tiltak
 løst. Handlingsplanen er et agendapunkt i alle ledermøter.
 
@@ -235,10 +235,10 @@ stadig endring. For tiden ser den slik ut:
 
 ### Frem til fadder blir satt (Rekrutteringsansvarlig)
 
-- Få den nyansatte til å fylle ut [nettsjema](http://nyansatt.variant.no) for
+- Få den nyansatte til å fylle ut [nettskjema](http://nyansatt.variant.no) for
   nyansatte. (Her velger du blant annet PC)
 - Opprett bruker for AD, Mail i office 365.
-- Etabler CV i CV-partner, og inviter den nyansette inn for å starte på dette
+- Etabler CV i CV-partner, og inviter den nyansatte inn for å starte på dette
   arbeidet.
 - Ta bilde til CV, helst i kroken hvor de andre bildene er tatt på DIGS
 - Tildele fadder
@@ -273,10 +273,10 @@ stadig endring. For tiden ser den slik ut:
 - Oppfølgingsprat etter et par uker for å høre hvordan oppstarten har vært
 - Ta et flott bilde av deg for din CV (men også for å vise verden hvor stolt vi
   er for å ha deg på laget).
-- Invitere inn i #salg på slack
+- Invitere inn i #salg på Slack
 - Fasilitere valg av personalleder etter 3 måneder
 - Oppdater malkortet Onboarding basert på erfaring fra siste onboarding. Hør med
-  nyansatt om hun eller han har inspill
+  nyansatt om hun eller han har innspill
 
 ## Personaloppfølging
 


### PR DESCRIPTION
Kjørte markdown-filene igjennom et linting-script som sjekker opp mot en norsk ordbok. Enkelte endringer er gjort for å ha litt mer uniform ordbruk. "Startups" i motsetning til "start-ups", "Trello-tavle" vs. "Trelloboard".