### PR TITLE
Lenke til sossisfond-oversikt for Trondheim

### DIFF
--- a/content/avdelinger/trondheim.md
+++ b/content/avdelinger/trondheim.md
@@ -101,7 +101,7 @@ Støttet opp mot ledergruppen av Mikael.
 ## Sossisfond
 
 En oversikt over hva sossisfondet er brukt til i Trondheim, og hvor mye som gjenstår for året finnes 
-[på Sharepoint](http://var.show/sossisfond).
+[på Sharepoint](http://var.show/sossisfond-trh).
 
 
 ## Helse, miljø og sikkerhet

--- a/content/avdelinger/trondheim.md
+++ b/content/avdelinger/trondheim.md
@@ -101,7 +101,7 @@ Støttet opp mot ledergruppen av Mikael.
 ## Sossisfond
 
 En oversikt over hva sossisfondet er brukt til i Trondheim, og hvor mye som gjenstår for året finnes 
-[på Sharepoint](http://var.show/sossisfond-trh).
+[på docs](http://var.show/sossisfond-trh).
 
 
 ## Helse, miljø og sikkerhet

--- a/content/avdelinger/trondheim.md
+++ b/content/avdelinger/trondheim.md
@@ -98,6 +98,11 @@ man også laste ned Apps for både Mac og telefoner.
 
 Støttet opp mot ledergruppen av Mikael.
 
+## Sossisfond
+
+En oversikt over hva sossisfondet er brukt til i Trondheim, og hvor mye som gjenstår for året finnes 
+[på Sharepoint](http://var.show/sossisfond).
+
 
 ## Helse, miljø og sikkerhet
 


### PR DESCRIPTION
Har laget et excelark som viser hva sossisfondet i Trondheim er brukt til, og hvor mye som gjenstår for året. PR-en legger inn lenke til dette regnearket under Trondheimssiden.