### PR TITLE
Adding section for fordelsavtaler with SATS fordelsavtale information

### DIFF
--- a/pages/information.mdx
+++ b/pages/information.mdx
@@ -302,6 +302,12 @@ elementer:
 Her finner dere informasjon om hvordan
 [benytte behandlingsforsikring](https://www.gjensidige.no/privat/meld-skade/behandlingsforsikring).
 
+## Fordelsavtaler
+
+### SATS
+
+Variant har en samarbeidsavtale med SATS som gir 15% rabatt på nye og eksisterende abonnement. [Les mer her](https://varianttrh.sharepoint.com/:b:/g/EbNkuLOu8X1NhFMzuEgXWoIBhzK-wSPBaOFGYlyzB_K3Aw?e=OwPdCE)
+
 ## Sossis-fond
 
 Vi har et fond på 50 000 NOK som kan brukes som midler til sosiale aktiviteter


### PR DESCRIPTION
Adding section for fordelsavtaler with SATS fordelsavtale information

Open for feedback on where to place this or if it should even be its own section. But I think its good to visualize that we have these kind of agreements and it can be expanded for whatever else we have - ie discounts for airplane operators etc 