### PR TITLE
Endre på setning som forklarer Slack

### DIFF
--- a/pages/information.mdx
+++ b/pages/information.mdx
@@ -427,8 +427,7 @@ spør du i #helpdesk 🤓
 - [UNI Economy](https://unieconomy.no/#/) for regnskap, faktura og lønn
 - [Office 365 Dokumenter](https://docs.variant.no) for lagring av dokumenter og
   andre filer.
-- [Slack](https://join.slack.com/t/variantas/signup) for å ... (ja det skjønner
-  du vel?)
+- [Slack](https://join.slack.com/t/variantas/signup) for å kommunisere med andre Varianter
 - [MS Office](https://admin.microsoft.com/OLS/MySoftware.aspx) lenken går til
   nedlastingssiden
 - [Åpne Web Analytics](https://variant.innocraft.cloud/)


### PR DESCRIPTION
Setningen for Slack er litt cocky og kan være missforstående for folk som ikke er så tekniske. Endre denne til litt mer forståelig.