### PR TITLE
feat: adds note on gadget when quitting

### DIFF
--- a/pages/information.mdx
+++ b/pages/information.mdx
@@ -606,7 +606,7 @@ Sum til skattemelding regnes ut i fra følgende:
 
 For enheter som er over 10 000 kr, må det kjøpes ut fra kostpris,
 men med noe justeringer for å gjore det rausere en lovene sier.
-Skatteetaten må fortsatt få det de ønsker, så differansen mellom
+Staten skal fortsatt få det de har krav på, så differansen mellom
 det du betaler og verdien fra forrige tabell må skattemeldes.
 
 <table>

--- a/pages/information.mdx
+++ b/pages/information.mdx
@@ -607,7 +607,7 @@ Sum til skattemelding regnes ut i fra følgende:
 For enheter som er over 10 000 kr, må det kjøpes ut fra kostpris,
 men med noe justeringer for å gjore det rausere en lovene sier.
 Staten skal fortsatt få det de har krav på, så differansen mellom
-det du betaler og verdien fra forrige tabell må skattemeldes.
+det du betaler og verdien fra forrige tabell må innberettes.
 
 <table>
   <thead>

--- a/pages/information.mdx
+++ b/pages/information.mdx
@@ -523,7 +523,7 @@ med deg og ditt barns rutiner her. Her gjelder det selvfølgelig å ha en god
 dialog med kunde på dette, så dagene er forutsigbare og enkle å planlegge rundt
 for alle involverte.
 
-### Gadgets
+## Gadgets
 
 Folk har lurt "Dette gadgetbudsjettet deres, hva kan det brukes til?" og svaret
 er at bare
@@ -537,20 +537,113 @@ Hvis du er i tvil så spør du i #regnskap på Slack.
 Pro tip: Tenk på at summen av kjøpet ditt regnes eksklusive mva., da rekker
 budsjettet ditt lenger!
 
-Pro tip 2: Husk at det er fullt mulig å kjøpe brukt! Det eneste vi trenger er dokumentasjon på 
+Pro tip 2: Husk at det er fullt mulig å kjøpe brukt! Det eneste vi trenger er dokumentasjon på
 kjøpet (f.eks skjermbilde av Finn-annonse og Vipps-kvittering)
 
-#### Størrelse på årlig beløp
-Akkurat nå er det årlige beløpet på 11 000 kr. Budsjettet øker altså med dette beløpet hver gang 
-du passerer oppstartsdatoen din 😀. 
+### Størrelse på årlig beløp
 
-Beløpets størrelse justeres med 
-[Konsumprisindeksen](https://www.ssb.no/priser-og-prisindekser/konsumpriser/statistikk/konsumprisindeksen) 
+Akkurat nå er det årlige beløpet på 11 000 kr. Budsjettet øker altså med dette beløpet hver gang
+du passerer oppstartsdatoen din 😀.
+
+Beløpets størrelse justeres med
+[Konsumprisindeksen](https://www.ssb.no/priser-og-prisindekser/konsumpriser/statistikk/konsumprisindeksen)
 og tar utgangspunkt i 10 000 kr pr september 2018, rundet ned til hele tusen kroner. Dette betyr at gadgetbudsjettet justeres med en gang endringene passerer en tusenlapp.
 
 Beløpshistorikk;
+
 - Aug 2018: 10 000 kr
 - Mai 2022: 11 000 kr
+
+Gadgetbudsjettet er basert på et helt år med ansettelse. I praksis betyr det litt
+gadgetbudsjett hver dag. Dette er gjort for å enklere se på gadgetbudsjett om noen
+slutter. Om noen slutter ett halvt år etter oppstartsdatoen din, vil det årlige
+budsjettet tilsvare 5 500 kr.
+
+### Gadgets ved fratredelse
+
+Ting kjøpt med selskapets penger er selskapets eiendom. Det er i alle
+fall det Skatteetaten sier. Det betyr at det er noen regler vi må
+forholde oss til om du slutter og har benyttet deg av gadgetbudsjettet.
+
+Variant ønsker jo ikke et lager med brukte tastaturer, sekker eller telefoner.
+Så her har vi lagt oss på en god linje som overholder krav fra revisor og
+Skatteetaten, men som fortsatt er ganske gunstig for de som slutter. Her er
+en oversikt over hvordan det håndteres.
+
+#### Beløp utover gjeldende budsjett (f.eks lånt av neste år, eller utover summen for året)
+
+Må betales tilbake. Eksempelvis trekkes av lønn.
+
+#### Gadgets med kjøpsverdi under 10 000 kr
+
+Meldes inn av Variant som skattbar inntekt i henhold til avskriving fra skatteloven.
+Sum til skattemelding regnes ut i fra følgende:
+
+<table>
+  <thead>
+    <tr>
+      <th>Alder</th>
+      <th>Verdi</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Mindre enn 1 år</td>
+      <td>80% av kostpris</td>
+    </tr>
+    <tr>
+      <td>1 år - 2 år</td>
+      <td>50% av kostpris</td>
+    </tr>
+    <tr>
+      <td>Over 2 år</td>
+      <td>20% av kostpris</td>
+    </tr>
+  </tbody>
+</table>
+
+#### Mobiltelefoner/andre enheter på verdi over 10 000 kr
+
+For enheter som er over 10 000 kr, må det kjøpes ut fra kostpris,
+men med noe justeringer for å gjore det rausere en lovene sier.
+Skatteetaten må fortsatt få det de ønsker, så differansen mellom
+det du betaler og verdien fra forrige tabell må skattemeldes.
+
+<table>
+  <thead>
+    <tr>
+      <th>Alder</th>
+      <th>Tilbakebetales</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Under halvt år</td>
+      <td>Kjøpe ut for 80% av kostpris</td>
+    </tr>
+    <tr>
+      <td>1/2 år - 2 år</td>
+      <td>Kjøpe ut for 50% av kostpris</td>
+    </tr>
+    <tr>
+      <td>Over 2 år</td>
+      <td>Samme som tabellen over (regnes som avskrevet).</td>
+    </tr>
+  </tbody>
+</table>
+
+Kan velge å ikke kjøpe ut men levere tilbake gadgeten.
+
+<div className="listGap background-color-secondary4__tint2">
+
+**Eksempel**
+
+Du har kjøpt en mobil til 15 000 kr for 8 måneder siden. Du ønsker å beholde mobilen,
+som nå har en markedsverdi på 50% av 15 000 kr; altså 7 500 kr.
+Skatteetaten sier at verdien på mobilen er 12 000 kr (tilsvarer 80%).
+Det vil derfor også rapporteres inn på skattbar inntekt på 4 500 kr (`12 000 - 7 500`).
+
+</div>
 
 ## Verktøykassen 🛠📚
 

--- a/src/app.css
+++ b/src/app.css
@@ -140,6 +140,21 @@ code {
   background-color: var(--color-secondary3);
 }
 
+table {
+  margin: 2rem 1rem;
+}
+table tbody tr td {
+  background: var(--color-secondary4__tint2);
+}
+table tbody tr:nth-child(2n + 1) td {
+  background: var(--color-secondary4__tint1);
+}
+
+table th,
+table td {
+  padding: 0.8rem;
+}
+
 a:visited {
   color: var(--color-standard__black);
   transition: color 250ms ease-in;


### PR DESCRIPTION
Legger til notis og eksempel på hvordan gadget budsjett håndteres ved fratredelse. Dette i henhold til besluttet praksis fra februar 2022 (kjapp leveransetid på denne). Se https://trello.com/c/MOOZoAK3/208-verdivurdering-gadget-ved-fratredelse for detaljer.