### PR TITLE
fix: backgroundblob size

### DIFF
--- a/src/layouts/general/layout.module.css
+++ b/src/layouts/general/layout.module.css
@@ -270,6 +270,8 @@
 
   background: url('./navBackground.svg') var(--color-secondary1__shade2) right -100px
     repeat-y;
+
+  background-size: cover;
 }
 
 .nav__background__active {
@@ -521,6 +523,7 @@
 @media (min-width: 1200px) {
   .nav {
     transform: translateX(0);
+    max-width: 25%;
   }
   .hamburger {
     display: none;


### PR DESCRIPTION
Vil ikke lenger bli et mellomrom mellom nav og ''bakgrunnsblobb'' på store enheter. Størrelsen på blobben vil skalere med bredden på siden