### PR TITLE
fix: header "transparent" on mobile

### DIFF
--- a/src/layouts/general/layout.module.css
+++ b/src/layouts/general/layout.module.css
@@ -45,7 +45,7 @@
   right: 0;
   z-index: 150;
   width: 100vw;
-  height: 6rem;
+  height: 0rem;
 }
 
 .header {
@@ -580,6 +580,7 @@
   .header__dark {
     z-index: 3;
     visibility: visible;
+    height: 6rem;
   }
 
   .header__handbooks,


### PR DESCRIPTION
Fikset en bug hvor headeren vil ha en bakgrunnsfarge på mobil

<img width="656" alt="Screenshot 2023-04-19 at 13 28 49" src="https://user-images.githubusercontent.com/110395932/233061414-0a28bc66-d25b-4676-ac1f-026bcff35c49.png">
<img width="580" alt="Screenshot 2023-04-19 at 13 29 06" src="https://user-images.githubusercontent.com/110395932/233061464-dacaf600-eb89-426e-bba4-14836013e59e.png">
