### PR TITLE
fix: smaller font size. Placeholder goes off screen on mobile

### DIFF
--- a/src/search/search.module.css
+++ b/src/search/search.module.css
@@ -62,6 +62,12 @@
   background-color: var(--color-secondary1__shade3);
 }
 
+@media (max-width: 700px) {
+  :global(.ais-SearchBox-input) {
+    font-size: 2rem;
+  }
+}
+
 :global(.ais-SearchBox-input::placeholder) {
   color: var(--color-standard__white);
 }


### PR DESCRIPTION
Når placeholderteksten er endret vil den være for stor for mindre enheter og bevege seg ut av skjermen. Har gjort et forsøk på å forhindre det ved å redusere fontstørrelsen. Mulig det finnes en bedre måte å løse det på men..