### PR TITLE
fix: adds link to titles for navigating to anchors

### DIFF
--- a/src/layouts/handbook/handbook.module.css
+++ b/src/layouts/handbook/handbook.module.css
@@ -1,16 +1,8 @@
-.anchor {
+.titleLink {
+  color: inherit;
   text-decoration: none;
-  font-size: 0.8em;
-  padding: 0 0.5rem;
-  align-self: baseline;
+}
 
-  /* Incase we want anchor tags after headings remove this!*/
-  display: none;
-}
-.anchor:visited,
-.anchor:link {
-  color: var(--color-secondary1__tint4);
-}
-.anchor:hover {
-  color: var(--color-primary);
+.titleLink:hover {
+  color: inherit;
 }

--- a/src/layouts/handbook/index.tsx
+++ b/src/layouts/handbook/index.tsx
@@ -11,7 +11,7 @@ function createLinkable(el: 'h2' | 'h3' | 'h4') {
   return ({ children, ...props }: JSX.IntrinsicElements[typeof el]) => {
     const textContent = getNodeText(children);
     const slug = slugify(textContent, { lower: false });
-    const childList = React.Children.toArray(children);
+
     return React.createElement(
       el,
       {
@@ -19,11 +19,9 @@ function createLinkable(el: 'h2' | 'h3' | 'h4') {
         id: slug,
         key: slug,
       },
-      childList.concat(
-        <a className={style.anchor} key="link" href={`#${slug}`}>
-          #
-        </a>,
-      ),
+      <a className={style.titleLink} href={`#${slug}`}>
+        {children}
+      </a>,
     );
   };
 }


### PR DESCRIPTION
Legger til lenke på titler. Fjerner den skigarden og heller har lenke direkte på tittel. Ikke uvanlig praksis på nettsider og unngår at det er et visuelt element på titlene i tillegg.