### PR TITLE
Setting Cicignons plass as the meeting place in the case of fire in Trondheim

### DIFF
--- a/pages/avdelinger/trondheim.mdx
+++ b/pages/avdelinger/trondheim.mdx
@@ -269,7 +269,7 @@ Gjør deg kjent med følgende i Varianthuset:
 - Nærmeste slukkemiddel
 
 Ved brannalarm, forlat bygningen gjennom rømningsveiene og gå deretter til
-[samlingsplassen mellom sykkelparkeringen og Dromedarbakeriet.](https://www.google.com/maps/@63.4323746,10.3995148,3a,75y,235.45h,90.05t/data=!3m6!1e1!3m4!1sgguaNK1F5B-QYaPrEXA0mA!2e0!7i16384!8i8192)
+[Cicignons plass, utenfor Egon](https://maps.app.goo.gl/5r4yAWahgR3R9eC76).
 Hvis brann oppstår uten at automatisk alarm er utløst, trykk på brannmelder hvis
 mulig og gå deretter ut av bygningen og til samlingsplassen.
 


### PR DESCRIPTION
Oppdaterer informasjon om samlingsplassen i tilfelle brann i Trondheim til Cicignons plass.