### PR TITLE
Fix text overflow inside illustrations

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -94,14 +94,12 @@ li + li {
   margin: 1rem 0;
 }
 .illustration {
-  width: 15rem;
-  margin: 5rem 2rem 2rem;
-  shape-outside: circle(55%);
+  width: 17rem;
+  shape-outside: circle(50%);
+  padding: 2rem;
 }
 .illustration--right {
   float: right;
-  margin: 3rem 0 2rem 2rem;
-  right: -4rem;
 }
 .illustration--left {
   float: left;
@@ -247,15 +245,7 @@ a:hover {
   }
   .illustration {
     max-width: 40%;
-    width: 13rem;
-  }
-  .illustration--right {
-    margin: 3rem 0 1rem 1rem;
-    right: -1rem;
-  }
-  .illustration--left {
-    margin: 3rem 1rem 1rem 0;
-    left: -1rem;
+    width: 15rem;
   }
   .illustration--center {
     margin: 0 auto;


### PR DESCRIPTION
Closes #314 

Not perfect, but hopefully better 😎 

Before             |  After
:-------------------------:|:-------------------------:
<img width="735" alt="image" src="https://github.com/user-attachments/assets/aeb361a2-62b5-4571-918b-df996e2ec5ad"> |  <img width="742" alt="image" src="https://github.com/user-attachments/assets/c20e5239-f955-46e3-9bdc-612635071510">
<img width="723" alt="image" src="https://github.com/user-attachments/assets/0874b1d8-434a-458e-8643-28d6fe255f60"> |  <img width="754" alt="image" src="https://github.com/user-attachments/assets/64555040-6a11-4478-bb41-853442230093">
<img width="761" alt="image" src="https://github.com/user-attachments/assets/feecc583-8b5c-4424-aae9-98b35e4ed827"> |  <img width="741" alt="image" src="https://github.com/user-attachments/assets/b9951b81-f197-4ad5-b3e6-d4880d452693">

