### PR TITLE
feat: added baerekraft heading for Trondheim and Bergen

### DIFF
--- a/pages/avdelinger/bergen.mdx
+++ b/pages/avdelinger/bergen.mdx
@@ -58,6 +58,8 @@ Hvis du får en faktura som skal betales av Variant Bergen sendes den til
 
 ## Helse, miljø og sikkerhet
 
+### Bærekraft
+
 ### Lokalt HMS-arbeid
 
 Variant er et konsulentselskap, der hvor mange ansatte tilbringer store deler av

--- a/pages/avdelinger/bergen.mdx
+++ b/pages/avdelinger/bergen.mdx
@@ -60,6 +60,11 @@ Hvis du får en faktura som skal betales av Variant Bergen sendes den til
 
 ### Bærekraft
 
+Vi gjør nok mange flere tiltak enn man skulle tro på bærekraftsfronten, som sertifisering gjennom Miljøfyrtårn, fortløpende klimaregnskap, og at hvert av selskapene våres skal streve etter å bli karbonnøytrale for hele sin levetid:
+
+- Som det yngste selskapet i Variant Norge jobber vi i Bergen nå med å etablere rutinene våres.
+  - For øyeblikket holder vi på å sertifisere oss som Miljøfyrtårn.
+
 ### Lokalt HMS-arbeid
 
 Variant er et konsulentselskap, der hvor mange ansatte tilbringer store deler av

--- a/pages/avdelinger/trondheim.mdx
+++ b/pages/avdelinger/trondheim.mdx
@@ -229,6 +229,11 @@ Medlemmer fra ledelsen:
 
 ### Bærekraft
 
+Vi gjør nok mange flere tiltak enn man skulle tro på bærekraftsfronten, som sertifisering gjennom Miljøfyrtårn, fortløpende klimaregnskap, og at hvert av selskapene våres skal streve etter å bli karbonnøytrale for hele sin levetid:
+
+- I Trondheim har vi vært sertifiserte som Miljøfyrtårn siden 2020, kartlagt våre utslipp i et klimaregnskap siden 2021, og innført karbonkompensering i 2022 som et tiltak for å oppnå karbonnøytralitet på sikt.
+- Nå jobber vi med å profesjonalisere rutinene våres i større grad, og se på hvordan vi kan utgjøre en større forskjell for kundene våre.
+
 ### Verneombud
 
 Selskapet skal legge til rette for at det velges et verneombud. Verneombudet

--- a/pages/avdelinger/trondheim.mdx
+++ b/pages/avdelinger/trondheim.mdx
@@ -227,6 +227,8 @@ Medlemmer fra ledelsen:
 - Kristin Qvenild Nesset
 - Magnus Olderø Sæther
 
+### Bærekraft
+
 ### Verneombud
 
 Selskapet skal legge til rette for at det velges et verneombud. Verneombudet


### PR DESCRIPTION
## Description
@strombraaten: We're doing this to make it easier to communicate Variant's sustainability work. It differs from city to city, and although our overarching goals are the same nationwide, we have different goals locally, and different areas of focus.

By adding a sub-section for each city we're making it easier for the people who needs to do the writing to actually.. do the writing.

## Links
[Trondheim-bærekraft](https://handbook-git-feat-baerekraft-heading-variant1.vercel.app/avdelinger/trondheim#Baerekraft)

[Bergen-bærekraft](https://handbook-git-feat-baerekraft-heading-variant1.vercel.app/avdelinger/bergen#Baerekraft)
