### PR TITLE
Fix link to 'Goder og ytelser'

### DIFF
--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -258,7 +258,7 @@ som Gjensidige kaller det. Forsikringen dekker:
 ### Samfunn
 
 Variant skal også bidra til nærmiljøet og samfunnet der vi finnes. Som beskrevet
-under [goder og ytelser](#andre-goder-og-ytelser) så har hver variant 12&nbsp;000 kr
+under [goder og ytelser](#Goder-og-ytelser) så har hver variant 12&nbsp;000 kr
 i året til å kjøpe gadgets/dingser for. Disse pengene kan også brukes til å sponse en
 frivillig eller veldedig organisasjon. Fotballaget til dattera, UNICEF eller eldrekafeen
 i bydelen. Valget er ditt!


### PR DESCRIPTION
#### Fix link to 'Goder og ytelser' 
The heading/anchor is `Goder og ytelser` rather than `Andre goder og ytelser`