### PR TITLE
Oppdaterer Håndboken med konkrete lederlønninger for 2026

### DIFF
--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -629,10 +629,10 @@ I 2026 er dette grunnlønnene for ledere i ledergruppen Variant Norge:
 - CTO: 1 837 500 kr
 - CDO: 1 837 500 kr
 - CPO: 1 651 200 kr
-- CEO Bergen: 1 647 650  kr
-- CEO Oslo: 1 765 500  kr
+- CEO Bergen: 1 647 650 kr
+- CEO Oslo: 1 765 500 kr
 - CEO Trondheim: 1 716 000 kr
-- CEO Stavanger: 1 496 400  kr
+- CEO Stavanger: 1 496 400 kr
 
 Videre har hvert enkelt selskap en ledergruppe hvor lønnen er omfattet av ordningen beskrevet over. Hva den enkelte tjener er tilgjengelig i hvert selskaps "Operativt"  (Et regneark, tilgjengelig for alle varianter, hvor blant annet lønnkostnader kalkuleres.) 
 


### PR DESCRIPTION
Oppdaterer håndboken med faktiske konkrete grunnnlønner for LGN i 2026